### PR TITLE
chore: Updates wasi-logging to have a version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,4 +11,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: WebAssembly/wit-abi-up-to-date@v15
+    - uses: WebAssembly/wit-abi-up-to-date@v22

--- a/imports.md
+++ b/imports.md
@@ -1,51 +1,51 @@
-<h1><a name="imports">World imports</a></h1>
+<h1><a id="imports"></a>World imports</h1>
 <ul>
 <li>Imports:
 <ul>
-<li>interface <a href="#wasi:logging_logging"><code>wasi:logging/logging</code></a></li>
+<li>interface <a href="#wasi_logging_logging_0_1_0_draft"><code>wasi:logging/logging@0.1.0-draft</code></a></li>
 </ul>
 </li>
 </ul>
-<h2><a name="wasi:logging_logging">Import interface wasi:logging/logging</a></h2>
+<h2><a id="wasi_logging_logging_0_1_0_draft"></a>Import interface wasi:logging/logging@0.1.0-draft</h2>
 <p>WASI Logging is a logging API intended to let users emit log messages with
 simple priority levels and context values.</p>
 <hr />
 <h3>Types</h3>
-<h4><a name="level"><code>enum level</code></a></h4>
+<h4><a id="level"></a><code>enum level</code></h4>
 <p>A log level, describing a kind of message.</p>
 <h5>Enum Cases</h5>
 <ul>
 <li>
-<p><a name="level.trace"><code>trace</code></a></p>
+<p><a id="level.trace"></a><code>trace</code></p>
 <p>Describes messages about the values of variables and the flow of
 control within a program.
 </li>
 <li>
-<p><a name="level.debug"><code>debug</code></a></p>
+<p><a id="level.debug"></a><code>debug</code></p>
 <p>Describes messages likely to be of interest to someone debugging a
 program.
 </li>
 <li>
-<p><a name="level.info"><code>info</code></a></p>
+<p><a id="level.info"></a><code>info</code></p>
 <p>Describes messages likely to be of interest to someone monitoring a
 program.
 </li>
 <li>
-<p><a name="level.warn"><code>warn</code></a></p>
+<p><a id="level.warn"></a><code>warn</code></p>
 <p>Describes messages indicating hazardous situations.
 </li>
 <li>
-<p><a name="level.error"><code>error</code></a></p>
+<p><a id="level.error"></a><code>error</code></p>
 <p>Describes messages indicating serious errors.
 </li>
 <li>
-<p><a name="level.critical"><code>critical</code></a></p>
+<p><a id="level.critical"></a><code>critical</code></p>
 <p>Describes messages indicating fatal errors.
 </li>
 </ul>
 <hr />
 <h3>Functions</h3>
-<h4><a name="log"><code>log: func</code></a></h4>
+<h4><a id="log"></a><code>log: func</code></h4>
 <p>Emit a log message.</p>
 <p>A log message has a <a href="#level"><code>level</code></a> describing what kind of message is being
 sent, a context, which is an uninterpreted string meant to help
@@ -53,7 +53,7 @@ consumers group similar messages, and a string containing the message
 text.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="log.level"><a href="#level"><code>level</code></a></a>: <a href="#level"><a href="#level"><code>level</code></a></a></li>
-<li><a name="log.context"><code>context</code></a>: <code>string</code></li>
-<li><a name="log.message"><code>message</code></a>: <code>string</code></li>
+<li><a id="log.level"></a><a href="#level"><code>level</code></a>: <a href="#level"><a href="#level"><code>level</code></a></a></li>
+<li><a id="log.context"></a><code>context</code>: <code>string</code></li>
+<li><a id="log.message"></a><code>message</code>: <code>string</code></li>
 </ul>

--- a/wit/world.wit
+++ b/wit/world.wit
@@ -1,4 +1,4 @@
-package wasi:logging;
+package wasi:logging@0.1.0-draft;
 
 world imports {
     import logging;


### PR DESCRIPTION
As I was starting to build and push all of these interfaces to work with wkg, I realized this didn't even have a version yet which means `wkg` won't even work with it. It also should just have a version. I am just making this a plain 0.1.0 because versions are free and they don't need to match the other p2 worlds. If we want to modify this, we just bump to a 0.2.0-beta or something similar